### PR TITLE
Feature: loop

### DIFF
--- a/app/js/directives/velocity-group.js
+++ b/app/js/directives/velocity-group.js
@@ -22,17 +22,28 @@ angular.module("sn.velocity.snVelocityGroup", [
         return {
             restrict: "E",
             scope: {
-                "keyframes": "="
+                "keyframes": "=",
+                "loop": "="
             },
             link: function($scope, $element){
 
                 angular.forEach($scope.keyframes, function(keyframes, key){
                     var animateElement = angular.element($element[0].querySelector(key));
                     var scope = $rootScope.$new();
-                    scope.keyframes = keyframes;
+                    scope.keyframes = keyframes.keyframes || keyframes;
 
                     animateElement.attr("sn-velocity", "");
                     animateElement.attr("data-keyframes", "keyframes");
+
+                    // pass loop option to velocity directive
+                    if ($scope.loop) {
+                        animateElement.attr("data-loop", "true");
+                    }
+
+                    // pass start delay from animation object to velocity directive
+                    if (keyframes.startDelay) {
+                        animateElement.attr("data-start-delay", keyframes.startDelay);
+                    }
 
                     $compile(animateElement)(scope);
                 });

--- a/app/js/directives/velocity.js
+++ b/app/js/directives/velocity.js
@@ -4,24 +4,59 @@
  * @author SOON_
  * @module sn.velocity.snVelocity
  * @class  snVelocity
- * @example <sn-velocity data-keyframes="[{'properties': { opacity: 0 }, 'options': { duration: 1000 }},{'properties': { opacity: 1 },'options': { duration: 1000 }}]"></sn-velocity>
+ * @example
+ *      <sn-velocity
+ *          data-keyframes="[{'properties': { opacity: 0 }, 'options': { duration: 1000 }},{'properties': { opacity: 1 },'options': { duration: 1000 }}]"
+ *          data-start-delay="1000"
+ *          data-loop
+ *      ></sn-velocity>
  */
 angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
     "$window",
+    "$timeout",
     /**
      * @constructor
      */
-    function($window) {
+    function($window, $timeout) {
         return {
             restrict: "A",
             scope: {
-                "keyframes": "="
+                "keyframes": "=",
+                "loop": "=?",
+                "startDelay": "=?"
             },
             link: function($scope, $element){
 
-                angular.forEach($scope.keyframes, function(value){
-                    $window.Velocity($element, value.properties, value.options);
-                });
+                /**
+                 * Run animation
+                 * @method animate
+                 */
+                $scope.animate = function animate() {
+                    angular.forEach($scope.keyframes, function(value){
+                        $window.Velocity($element, value.properties, value.options);
+                    });
+                };
+
+                /**
+                 * Trigger animation, with loop or start delay on initialisation
+                 * @method init
+                 */
+                $scope.init = function init() {
+
+                    // loop - call animation on completion of the last keyframe
+                    if ($scope.loop) {
+                        $scope.keyframes[$scope.keyframes.length - 1].options.complete = $scope.animate;
+                    }
+
+                    // start delay - run animation on init or with start delay
+                    if ($scope.startDelay) {
+                        $timeout($scope.animate, $scope.startDelay);
+                    } else {
+                        $scope.animate();
+                    }
+                };
+
+                $scope.init();
 
             }
         };

--- a/tests/unit/directives/velocity-group.js
+++ b/tests/unit/directives/velocity-group.js
@@ -43,5 +43,57 @@ describe("directive: snVelocityGroup", function() {
         expect(animateElement.attr("data-keyframes")).toEqual("keyframes");
     });
 
+    describe("option: loop", function(){
+
+        beforeEach(inject(function ($rootScope, $compile, $injector) {
+            scope = $rootScope.$new();
+
+            element =
+                "<sn-velocity-group data-loop=\"true\" data-keyframes=\"{ '#elem1': [{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }] }\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</sn-velocity-group>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+
+        }));
+
+        it("should attach directive options to scope", function (){
+            expect(isolatedScope.loop).toBeTruthy();
+        });
+
+        it("should pass loop option to velcoity directive", function (){
+            var animateElement = angular.element(element).find("div");
+            expect(animateElement.attr("data-loop")).toBeTruthy();
+        });
+
+    });
+
+    describe("option: startDelay", function(){
+
+        beforeEach(inject(function ($rootScope, $compile, $injector) {
+            scope = $rootScope.$new();
+
+            element =
+                "<sn-velocity-group data-keyframes=\"{ '#elem1': { 'keyframes': [{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }], 'startDelay': '200' } }\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</sn-velocity-group>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+
+        }));
+
+        it("should pass startDelay option from animation object to velocity directives", function (){
+            var animateElement = angular.element(element).find("div");
+            expect(animateElement.attr("data-start-delay")).toEqual("200");
+        });
+
+    });
+
 });
 

--- a/tests/unit/directives/velocity.js
+++ b/tests/unit/directives/velocity.js
@@ -34,5 +34,54 @@ describe("directive: snVelocity", function() {
         expect(spy).toHaveBeenCalledWith(element, { 'opacity': '1' }, { 'duration': '1000' });
     });
 
+    describe("option: loop", function(){
+
+        beforeEach(inject(function ($rootScope, $compile) {
+            scope = $rootScope.$new();
+
+            element =
+                "<div sn-velocity data-loop=\"true\" data-keyframes=\"[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</div>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+        }));
+
+        it("should attach directive options to scope", function(){
+            expect(isolatedScope.loop).toBeTruthy();
+        });
+
+        it("should add complete function to last keyframe", function(){
+            expect(isolatedScope.keyframes[0].options.complete).toEqual(isolatedScope.animate);
+        });
+
+    });
+
+    describe("option: startDelay", function(){
+
+
+        beforeEach(inject(function ($rootScope, $compile, $injector) {
+            scope = $rootScope.$new();
+
+            element =
+                "<div sn-velocity data-start-delay=\"1000\" data-keyframes=\"[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</div>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+        }));
+
+        it("should attach directive options to scope", function(){
+            expect(isolatedScope.startDelay).toEqual(1000);
+        });
+
+    });
+
 });
 


### PR DESCRIPTION
This PR proposes a `loop` option which enables animation looping on a set of keyframes and a `start delay` option to delay the start of an animation.

Both of these options are set on the velocity directive:

``` html
<div sn-velocity data-loop="true" data-start-delay="1000" data-keyframes="..."></div>
```

And can also be initialised via the velocityGroup directive:

``` html
<sn-velocity-group data-loop="true" data-keyframes="{ '#elem1': { 'keyframes': [{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }], 'startDelay': '200' } }"></div>
```

This requires a new format for the keyframes object to allow each animation element in the group to have it's own start delay. This does not break the old format, this directive now accepts either format.
