### PR TITLE
Feature: start delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Angular Velocity 
+# Angular Velocity
 
 [![Build Status](https://travis-ci.org/thisissoon/angular-velocity.svg?branch=develop)](https://travis-ci.org/thisissoon/angular-velocity)
 [![Coverage Status](https://coveralls.io/repos/thisissoon/angular-velocity/badge.svg)](https://coveralls.io/r/thisissoon/angular-velocity)
@@ -31,6 +31,13 @@ The loop option enables looping over a set of keyframes and is set by the boolea
 
 ```html
   <div sn-velocity data-loop data-keyframes="[]"></div>
+```
+
+#### Start Delay
+The start delay option delays the start of the animation by a set number of ms and is set by the attribute `data-start-delay`.
+
+```html
+  <div sn-velocity data-start-delay="1000" data-keyframes="[]"></div>
 ```
 
 ## Animation Groups
@@ -98,7 +105,7 @@ We have two kinds of dependencies in this project: tools and angular framework c
 The following tools require super user privileges so you will need to install them separately like so:
 
 ```
-sudo npm install -g bower 
+sudo npm install -g bower
 sudo npm install -g grunt-cli
 ```
 
@@ -161,11 +168,11 @@ To watch all files run:
 grunt serverall
 ```
 
-To run tests or compile less to css when the relevent files are updated. 
+To run tests or compile less to css when the relevent files are updated.
 
 ### Running the build script
 
-To create a build to deploy for a production environment simply run: 
+To create a build to deploy for a production environment simply run:
 
 ```
 grunt build
@@ -194,7 +201,7 @@ modules/                --> static html files for building and testing styling a
     index.html
 tests/                  --> test config and source files
   e2e/                  --> end-to-end specs
-    specs/              
+    specs/
       scenarios.js
     protractor.conf.js  --> config file for running e2e tests with Protractor
   unit/                 --> unit level specs/tests
@@ -260,7 +267,7 @@ grunt e2e
 ```
 
 Behind the scenes this will also run `webdriver-manager update && webdriver-manager start`. This will download and install the latest version of the stand-alone WebDriver tool and start the Selenium web server. This script will execute the end-to-end tests against the application being hosted on the
-development server. 
+development server.
 
 
 ## Contact

--- a/app/js/directives/velocity-group.js
+++ b/app/js/directives/velocity-group.js
@@ -29,10 +29,17 @@ angular.module("sn.velocity.snVelocityGroup", [
                 angular.forEach($scope.keyframes, function(keyframes, key){
                     var animateElement = angular.element($element[0].querySelector(key));
                     var scope = $rootScope.$new();
-                    scope.keyframes = keyframes;
+
+                    // pass keyframes directly from keyframes array or from animation object with keyframes key
+                    scope.keyframes = keyframes.keyframes || keyframes;
 
                     animateElement.attr("sn-velocity", "");
                     animateElement.attr("data-keyframes", "keyframes");
+
+                    // pass start delay from animation object to velocity directive
+                    if (keyframes.startDelay) {
+                        animateElement.attr("data-start-delay", keyframes.startDelay);
+                    }
 
                     $compile(animateElement)(scope);
                 });

--- a/app/js/directives/velocity.js
+++ b/app/js/directives/velocity.js
@@ -45,6 +45,10 @@ angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
 
                     // start delay - run animation on init or with start delay
                     if ($scope.startDelay) {
+                        if (timer) {
+                            $timeout.cancel(timer);
+                        }
+
                         timer = $timeout($scope.animate, $scope.startDelay);
                     } else {
                         $scope.animate();
@@ -56,7 +60,9 @@ angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
                  * @method onDestroy
                  */
                 $scope.onDestroy = function onDestroy() {
-                    timer.cancel();
+                    if (timer) {
+                        $timeout.cancel(timer);
+                    }
                 };
 
                 $scope.$on("$destroy", $scope.onDestroy);

--- a/app/js/directives/velocity.js
+++ b/app/js/directives/velocity.js
@@ -4,24 +4,64 @@
  * @author SOON_
  * @module sn.velocity.snVelocity
  * @class  snVelocity
- * @example <sn-velocity data-keyframes="[{'properties': { opacity: 0 }, 'options': { duration: 1000 }},{'properties': { opacity: 1 },'options': { duration: 1000 }}]"></sn-velocity>
+ * @example
+ *      <sn-velocity
+ *          data-keyframes="[{'properties': { opacity: 0 }, 'options': { duration: 1000 }},{'properties': { opacity: 1 },'options': { duration: 1000 }}]"
+ *          data-start-delay="1000"
+ *      ></sn-velocity>
  */
 angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
     "$window",
+    "$timeout",
     /**
      * @constructor
      */
-    function($window) {
+    function($window, $timeout) {
         return {
             restrict: "A",
             scope: {
-                "keyframes": "="
+                "keyframes": "=",
+                "startDelay": "=?"
             },
             link: function($scope, $element){
 
-                angular.forEach($scope.keyframes, function(value){
-                    $window.Velocity($element, value.properties, value.options);
-                });
+                var timer;
+
+                /**
+                 * Run animation
+                 * @method animate
+                 */
+                $scope.animate = function animate() {
+                    angular.forEach($scope.keyframes, function(value){
+                        $window.Velocity($element, value.properties, value.options);
+                    });
+                };
+
+                /**
+                 * Trigger animation, with loop or start delay on initialisation
+                 * @method init
+                 */
+                $scope.init = function init() {
+
+                    // start delay - run animation on init or with start delay
+                    if ($scope.startDelay) {
+                        timer = $timeout($scope.animate, $scope.startDelay);
+                    } else {
+                        $scope.animate();
+                    }
+                };
+
+                /**
+                 * Clear all listeners during angularjs garbage collection
+                 * @method onDestroy
+                 */
+                $scope.onDestroy = function onDestroy() {
+                    timer.cancel();
+                };
+
+                $scope.$on("$destroy", $scope.onDestroy);
+
+                $scope.init();
 
             }
         };

--- a/tests/unit/directives/velocity-group.js
+++ b/tests/unit/directives/velocity-group.js
@@ -43,5 +43,29 @@ describe("directive: snVelocityGroup", function() {
         expect(animateElement.attr("data-keyframes")).toEqual("keyframes");
     });
 
+    describe("option: startDelay", function(){
+
+        beforeEach(inject(function ($rootScope, $compile, $injector) {
+            scope = $rootScope.$new();
+
+            element =
+                "<sn-velocity-group data-keyframes=\"{ '#elem1': { 'keyframes': [{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }], 'startDelay': '200' } }\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</sn-velocity-group>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+
+        }));
+
+        it("should pass startDelay option from animation object to velocity directives", function (){
+            var animateElement = angular.element(element).find("div");
+            expect(animateElement.attr("data-start-delay")).toEqual("200");
+        });
+
+    });
+
 });
 

--- a/tests/unit/directives/velocity.js
+++ b/tests/unit/directives/velocity.js
@@ -34,5 +34,28 @@ describe("directive: snVelocity", function() {
         expect(spy).toHaveBeenCalledWith(element, { 'opacity': '1' }, { 'duration': '1000' });
     });
 
+    describe("option: startDelay", function(){
+
+
+        beforeEach(inject(function ($rootScope, $compile, $injector) {
+            scope = $rootScope.$new();
+
+            element =
+                "<div sn-velocity data-start-delay=\"1000\" data-keyframes=\"[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</div>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+        }));
+
+        it("should attach directive options to scope", function(){
+            expect(isolatedScope.startDelay).toEqual(1000);
+        });
+
+    });
+
 });
 


### PR DESCRIPTION
Adds the option to start animation after a specified time delay.

And can also be initialised via the velocityGroup directive:

``` html
<sn-velocity-group data-keyframes="{ '#elem1': { 'keyframes': [{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }], 'startDelay': '200' } }"></div>
```

This requires a new format for the keyframes object to allow each animation element in the group to have it's own start delay. This does not break the old format, this directive now accepts either format.
