### PR TITLE
Feature: loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ bower install velocity
 ```
 The `data-keyframes` attribute takes an array of velocity.js animation keyframes. See the [Velocity Docs](http://julian.com/research/velocity/#propertiesMap) for available properties and options.
 
+### Options
+
+#### Loop
+The loop option enables looping over a set of keyframes and is set by the boolean attribute `data-loop`.
+
+```html
+  <div sn-velocity data-loop data-keyframes="[]"></div>
+```
 
 ## Animation Groups
 

--- a/app/js/directives/velocity-group.js
+++ b/app/js/directives/velocity-group.js
@@ -37,7 +37,7 @@ angular.module("sn.velocity.snVelocityGroup", [
 
                     // pass loop option to velocity directive
                     if ($scope.loop) {
-                        animateElement.attr("data-loop", "true");
+                        animateElement.attr("data-loop", "");
                     }
 
                     $compile(animateElement)(scope);

--- a/app/js/directives/velocity-group.js
+++ b/app/js/directives/velocity-group.js
@@ -22,7 +22,8 @@ angular.module("sn.velocity.snVelocityGroup", [
         return {
             restrict: "E",
             scope: {
-                "keyframes": "="
+                "keyframes": "=",
+                "loop": "="
             },
             link: function($scope, $element){
 
@@ -33,6 +34,11 @@ angular.module("sn.velocity.snVelocityGroup", [
 
                     animateElement.attr("sn-velocity", "");
                     animateElement.attr("data-keyframes", "keyframes");
+
+                    // pass loop option to velocity directive
+                    if ($scope.loop) {
+                        animateElement.attr("data-loop", "true");
+                    }
 
                     $compile(animateElement)(scope);
                 });

--- a/app/js/directives/velocity.js
+++ b/app/js/directives/velocity.js
@@ -20,10 +20,9 @@ angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
         return {
             restrict: "A",
             scope: {
-                "keyframes": "=",
-                "loop": "=?"
+                "keyframes": "="
             },
-            link: function($scope, $element){
+            link: function($scope, $element, $attrs){
 
                 /**
                  * Run animation
@@ -42,7 +41,7 @@ angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
                 $scope.init = function init() {
 
                     // loop - call animation on completion of the last keyframe
-                    if ($scope.loop) {
+                    if ($attrs.hasOwnProperty("loop")) {
                         $scope.keyframes[$scope.keyframes.length - 1].options.complete = $scope.animate;
                     }
 

--- a/app/js/directives/velocity.js
+++ b/app/js/directives/velocity.js
@@ -4,24 +4,52 @@
  * @author SOON_
  * @module sn.velocity.snVelocity
  * @class  snVelocity
- * @example <sn-velocity data-keyframes="[{'properties': { opacity: 0 }, 'options': { duration: 1000 }},{'properties': { opacity: 1 },'options': { duration: 1000 }}]"></sn-velocity>
+ * @example
+ *      <sn-velocity
+ *          data-keyframes="[{'properties': { opacity: 0 }, 'options': { duration: 1000 }},{'properties': { opacity: 1 },'options': { duration: 1000 }}]"
+ *          data-loop
+ *      ></sn-velocity>
  */
 angular.module("sn.velocity.snVelocity", []).directive("snVelocity",[
     "$window",
+    "$timeout",
     /**
      * @constructor
      */
-    function($window) {
+    function($window, $timeout) {
         return {
             restrict: "A",
             scope: {
-                "keyframes": "="
+                "keyframes": "=",
+                "loop": "=?"
             },
             link: function($scope, $element){
 
-                angular.forEach($scope.keyframes, function(value){
-                    $window.Velocity($element, value.properties, value.options);
-                });
+                /**
+                 * Run animation
+                 * @method animate
+                 */
+                $scope.animate = function animate() {
+                    angular.forEach($scope.keyframes, function(value){
+                        $window.Velocity($element, value.properties, value.options);
+                    });
+                };
+
+                /**
+                 * Trigger animation, with loop or start delay on initialisation
+                 * @method init
+                 */
+                $scope.init = function init() {
+
+                    // loop - call animation on completion of the last keyframe
+                    if ($scope.loop) {
+                        $scope.keyframes[$scope.keyframes.length - 1].options.complete = $scope.animate;
+                    }
+
+                    $scope.animate();
+                };
+
+                $scope.init();
 
             }
         };

--- a/tests/unit/directives/velocity-group.js
+++ b/tests/unit/directives/velocity-group.js
@@ -43,5 +43,33 @@ describe("directive: snVelocityGroup", function() {
         expect(animateElement.attr("data-keyframes")).toEqual("keyframes");
     });
 
+    describe("option: loop", function(){
+
+        beforeEach(inject(function ($rootScope, $compile, $injector) {
+            scope = $rootScope.$new();
+
+            element =
+                "<sn-velocity-group data-loop=\"true\" data-keyframes=\"{ '#elem1': [{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }] }\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</sn-velocity-group>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+
+        }));
+
+        it("should attach directive options to scope", function (){
+            expect(isolatedScope.loop).toBeTruthy();
+        });
+
+        it("should pass loop option to velcoity directive", function (){
+            var animateElement = angular.element(element).find("div");
+            expect(animateElement.attr("data-loop")).toBeTruthy();
+        });
+
+    });
+
 });
 

--- a/tests/unit/directives/velocity-group.js
+++ b/tests/unit/directives/velocity-group.js
@@ -66,7 +66,7 @@ describe("directive: snVelocityGroup", function() {
 
         it("should pass loop option to velcoity directive", function (){
             var animateElement = angular.element(element).find("div");
-            expect(animateElement.attr("data-loop")).toBeTruthy();
+            expect(animateElement.attr("data-loop")).toBeDefined();
         });
 
     });

--- a/tests/unit/directives/velocity.js
+++ b/tests/unit/directives/velocity.js
@@ -40,7 +40,7 @@ describe("directive: snVelocity", function() {
             scope = $rootScope.$new();
 
             element =
-                "<div sn-velocity data-loop=\"true\" data-keyframes=\"[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]\">" +
+                "<div sn-velocity data-loop data-keyframes=\"[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]\">" +
                     "<div id=\"elem1\"></div>" +
                 "</div>";
 
@@ -49,10 +49,6 @@ describe("directive: snVelocity", function() {
 
             isolatedScope = element.isolateScope();
         }));
-
-        it("should attach directive options to scope", function(){
-            expect(isolatedScope.loop).toBeTruthy();
-        });
 
         it("should add complete function to last keyframe", function(){
             expect(isolatedScope.keyframes[0].options.complete).toEqual(isolatedScope.animate);

--- a/tests/unit/directives/velocity.js
+++ b/tests/unit/directives/velocity.js
@@ -34,5 +34,31 @@ describe("directive: snVelocity", function() {
         expect(spy).toHaveBeenCalledWith(element, { 'opacity': '1' }, { 'duration': '1000' });
     });
 
+    describe("option: loop", function(){
+
+        beforeEach(inject(function ($rootScope, $compile) {
+            scope = $rootScope.$new();
+
+            element =
+                "<div sn-velocity data-loop=\"true\" data-keyframes=\"[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]\">" +
+                    "<div id=\"elem1\"></div>" +
+                "</div>";
+
+            element = $compile(element)(scope);
+            scope.$digest();
+
+            isolatedScope = element.isolateScope();
+        }));
+
+        it("should attach directive options to scope", function(){
+            expect(isolatedScope.loop).toBeTruthy();
+        });
+
+        it("should add complete function to last keyframe", function(){
+            expect(isolatedScope.keyframes[0].options.complete).toEqual(isolatedScope.animate);
+        });
+
+    });
+
 });
 


### PR DESCRIPTION
This PR proposes a `loop` option which enables animation looping on a set of keyframes.

This option is set on the velocity directive:

``` html
<div sn-velocity data-loop="true" data-keyframes="..."></div>
```

And can also be initialised via the velocityGroup directive:

``` html
<sn-velocity-group data-loop="true" data-keyframes="[{ 'properties': { 'opacity': '1' }, 'options': { 'duration': '1000' } }]"></div>
```
